### PR TITLE
Add support for className prop

### DIFF
--- a/dist/react-loading.js
+++ b/dist/react-loading.js
@@ -121,10 +121,12 @@ return /******/ (function(modules) { // webpackBootstrap
 	        height: this.props.height,
 	        width: this.props.width
 	      };
+	      var className = this.props.className;
 
 	      return _react2['default'].createElement('div', {
 	        style: style,
-	        dangerouslySetInnerHTML: { __html: svg }
+	        dangerouslySetInnerHTML: { __html: svg },
+	        className: className
 	      });
 	    }
 	  }]);
@@ -139,14 +141,16 @@ return /******/ (function(modules) { // webpackBootstrap
 	  delay: _react.PropTypes.number,
 	  height: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.string]),
 	  type: _react.PropTypes.string,
-	  width: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.string])
+	  width: _react.PropTypes.oneOfType([_react.PropTypes.number, _react.PropTypes.string]),
+	  className: _react.PropTypes.string
 	};
 	Loading.defaultProps = {
 	  color: '#fff',
 	  delay: 1000,
 	  height: 64,
 	  type: 'balls',
-	  width: 64
+	  width: 64,
+	  className: ''
 	};
 	module.exports = exports['default'];
 

--- a/lib/react-loading.js
+++ b/lib/react-loading.js
@@ -32,11 +32,13 @@ export default class Loading extends Component {
       height: this.props.height,
       width: this.props.width
     };
+    const className = this.props.className;
 
     return (
       <div
         style={style}
         dangerouslySetInnerHTML={{__html:svg}}
+        className={className}
       />
     );
   }
@@ -52,12 +54,14 @@ Loading.propTypes = {
   width: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.string
-  ])
+  ]),
+  className: PropTypes.string,
 };
 Loading.defaultProps = {
   color: '#fff',
   delay: 1000,
   height: 64,
   type: 'balls',
-  width: 64
+  width: 64,
+  className: ''
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-loading",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "description": "React loading component",
   "main": "dist/react-loading.js",
   "scripts": {


### PR DESCRIPTION
# What does this do?
Adds support for the component to handle the `className` prop. 

# Related Issue
Fixes #17 - Passing a CSS Class